### PR TITLE
Implement minimum viable Task specification

### DIFF
--- a/api/v1alpha1/task_types.go
+++ b/api/v1alpha1/task_types.go
@@ -27,11 +27,14 @@ import (
 
 // TaskSpec defines the desired state of Task
 type TaskSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// The command AME will use to execute the Task.
+	// The command must be runnable from a bash shell.
+	// TODO: define propper requirements for the run command.
+	RunCommand string `json:"runcommand,omitempty"`
 
-	// Foo is an example field of Task. Edit task_types.go to remove/update
-	Foo string `json:"foo,omitempty"`
+	// A unique identifier for the project wich the Task will
+	// be running based on.
+	ProjectId string `json:"projectid,omitempty"`
 }
 
 // TaskStatus defines the observed state of Task

--- a/config/crd/bases/ame.teainspace.com_tasks.yaml
+++ b/config/crd/bases/ame.teainspace.com_tasks.yaml
@@ -35,9 +35,14 @@ spec:
           spec:
             description: TaskSpec defines the desired state of Task
             properties:
-              foo:
-                description: Foo is an example field of Task. Edit task_types.go to
-                  remove/update
+              projectid:
+                description: A unique identifier for the project wich the Task will
+                  be running based on.
+                type: string
+              runcommand:
+                description: 'The command AME will use to execute the Task. The command
+                  must be runnable from a bash shell. TODO: define propper requirements
+                  for the run command.'
                 type: string
             type: object
           status:


### PR DESCRIPTION
Inorder to progress the development of AME a minimum specification is
required which contains the bare minimum for AME to execute a Task. This
will allow for other features of AME to be implemented while the
specification is refined.

Therefore this commit implements a simple but usable specification for a Task.
