### PR TITLE
WIP implementing argo configuration correction

### DIFF
--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -20,7 +20,21 @@ func genTask(name string, namespace string) amev1alpha1.Task {
 	return amev1alpha1.Task{
 		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
 		TypeMeta:   v1.TypeMeta{APIVersion: "ame.teainspace.com/v1alpha1", Kind: "Task"},
+		Spec: amev1alpha1.TaskSpec{
+			RunCommand: "python train.py",
+			ProjectId:  "myprojectid",
+		},
 	}
+}
+
+func getParameterByName(parameters []argo.Parameter, name string) argo.Parameter {
+	for _, p := range parameters {
+		if p.Name == name {
+			return p
+		}
+	}
+
+	return argo.Parameter{}
 }
 
 var _ = Describe("Task execution", func() {
@@ -88,6 +102,112 @@ var _ = Describe("Task execution", func() {
 				"UID": Not(Equal(expectedWorkflow.UID)),
 			}),
 		}))
+	})
+
+	It("Should reconfigure a Workflow's parameters if they have been misconfigured", func() {
+		ctx := context.Background()
+		test := genTask(gofakeit.Noun(), testNamespace)
+		test.Spec.ProjectId = gofakeit.UUID()
+
+		correctParams := genParameters(test.Spec)
+
+		err := k8sClient.Create(ctx, &test)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Cover every potential misconfiguration of the Workflow parameters.
+		// TODO when replacing ginkgo with go test we should reimplemented this test as a table driven test.
+		testCases := [][]argo.Parameter{
+			// Tests that a parameter with an incorrect name and value is removed and the missing requird parameter(s) are put in the parameter list.
+			{
+				{
+					Name:  "wrong-name",
+					Value: argo.AnyStringPtr("wrong-value"),
+				},
+				getParameterByName(correctParams, "run-command"),
+			},
+
+			// Tests that a parameter wrong value is replaced with the correct value.
+			{
+				{
+					Name:  "run-command",
+					Value: argo.AnyStringPtr("wrong-value"),
+				},
+				getParameterByName(correctParams, "project-id"),
+			},
+
+			// Tests that parameters with an incorrect name but a correct value are replaced.
+			{
+				getParameterByName(correctParams, "run-command"),
+				{
+					Name:  "wrong-name2",
+					Value: argo.AnyStringPtr(getParameterByName(correctParams, "project-id").Value),
+				},
+			},
+
+			// Tests that excess parameters are removed, when all reqired parameters are present.
+			{
+				{
+					Name:  "wrong-name",
+					Value: argo.AnyStringPtr("wrong-value"),
+				},
+				correctParams[0],
+				correctParams[1],
+			},
+
+			// Tests that missing correct parameters are put back in the parameter list.
+			{
+				correctParams[1],
+			},
+		}
+
+		// Ensure that we are testing with filled out parameters.
+		for _, p := range correctParams {
+			Expect(p.Value.String()).ToNot(BeEmpty())
+		}
+
+		for _, testCase := range testCases {
+			// Ensure that the workflow configuration is correct before changing it.
+			wf := argo.Workflow{}
+			Eventually(func() (argo.Workflow, error) {
+				err := getArgoWorkflow(ctx, k8sClient, test, &wf)
+				return wf, err
+			}).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Spec": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Arguments": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Parameters": Equal(correctParams),
+					}),
+				}),
+			}))
+
+			// Change the Workflow specification so it uses the test case parameters.
+			wf.Spec.Arguments.Parameters = testCase
+
+			err = k8sClient.Update(ctx, &wf)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Validate that the workflow in the cluster has the intended changes.
+			// TODO this validation is not great, as it requires the cluster
+			// controller to be slow enough to reconcile so we can catch the mis
+			// configured Workflow before it is corrected.
+			// If having this extra validation makes sense to keep we need should
+			// implement a time independent method of validating the changes to
+			// the cluster so we know the test will always work.
+			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(&wf), &wf)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(wf.Spec.Arguments.Parameters).To(Equal(testCase))
+
+			// Ensure the Workflow configuration is corrected.
+			Eventually(func() (argo.Workflow, error) {
+				err := getArgoWorkflow(ctx, k8sClient, test, &wf)
+				return wf, err
+			}).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Spec": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Arguments": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Parameters": Equal(correctParams),
+					}),
+				}),
+			}))
+		}
 	})
 
 	// TODO: should we test that workflows are not recreated if one already exists for a task?


### PR DESCRIPTION
Issue: 7

This commit implements support for the project-id and run-command
for in the Task specification. The controller will now generate
Workflows with appropriate arguments based on these two fields and
reconcile and correct workflows with Misconfigured arguments.

The test for Workflow argument reconciliation uses a sort of table
driven test with a wide range of cases meant to cover any possible sort
of misconfiguration. For the future it would probably be a good idea to
look into auto generating these cases, especially then the
specificationg grows more complex.

Also the table driven tests should be refacored when removing ginkgo to
follow the format suggested in the github wiki for go table driven tests
with go test. This will run each case as a separate test and make i
obvious which cases fails and why.
