### PR TITLE
Implement server port configuration

### DIFF
--- a/cmd/ame/cmd/run.go
+++ b/cmd/ame/cmd/run.go
@@ -33,7 +33,7 @@ func runTask(cmd *cobra.Command, args []string) {
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-	conn, err := grpc.Dial("172.18.255.200:3000", opts...)
+	conn, err := grpc.Dial("172.18.255.200:3342", opts...)
 	if err != nil {
 		panic(err)
 	}

--- a/config/server/server.yaml
+++ b/config/server/server.yaml
@@ -28,14 +28,14 @@ spec:
           allowPrivilegeEscalation: false
         readinessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3000"]
+            command: ["/bin/grpc_health_probe", "-addr=:3342"]
           initialDelaySeconds: 5
         livenessProbe:
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3000"]
+            command: ["/bin/grpc_health_probe", "-addr=:3342"]
           initialDelaySeconds: 10
         ports:
-          - containerPort: 3000
+          - containerPort: 3342
         # TODO(user): Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
@@ -45,6 +45,12 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        env:
+          - name: AME_SERVER_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: ame-server-configmap
+                key: server_port
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
 ---
@@ -57,6 +63,12 @@ spec:
   selector:
     app: ame-server
   ports:
-    - port: 3000
-      targetPort: 3000
-
+    - port: 3342
+      targetPort: 3342
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ame-server-configmap
+data:
+  server_port: "3342"

--- a/generated/clientset/versioned/clientset.go
+++ b/generated/clientset/versioned/clientset.go
@@ -20,8 +20,8 @@ package versioned
 
 import (
 	"fmt"
-	"net/http"
 	amev1alpha1 "teainspace.com/ame/generated/clientset/versioned/typed/ame/v1alpha1"
+	"net/http"
 
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"

--- a/generated/clientset/versioned/fake/register.go
+++ b/generated/clientset/versioned/fake/register.go
@@ -19,12 +19,12 @@ limitations under the License.
 package fake
 
 import (
+	amev1alpha1 "teainspace.com/ame/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	amev1alpha1 "teainspace.com/ame/api/v1alpha1"
 )
 
 var scheme = runtime.NewScheme()

--- a/generated/clientset/versioned/scheme/register.go
+++ b/generated/clientset/versioned/scheme/register.go
@@ -19,12 +19,12 @@ limitations under the License.
 package scheme
 
 import (
+	amev1alpha1 "teainspace.com/ame/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	amev1alpha1 "teainspace.com/ame/api/v1alpha1"
 )
 
 var Scheme = runtime.NewScheme()

--- a/generated/clientset/versioned/typed/ame/v1alpha1/ame_client.go
+++ b/generated/clientset/versioned/typed/ame/v1alpha1/ame_client.go
@@ -19,11 +19,11 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"net/http"
 	"teainspace.com/ame/generated/clientset/versioned/scheme"
+	"net/http"
 
-	rest "k8s.io/client-go/rest"
 	v1alpha1 "teainspace.com/ame/api/v1alpha1"
+	rest "k8s.io/client-go/rest"
 )
 
 type AmeV1alpha1Interface interface {

--- a/generated/clientset/versioned/typed/ame/v1alpha1/fake/fake_task.go
+++ b/generated/clientset/versioned/typed/ame/v1alpha1/fake/fake_task.go
@@ -21,13 +21,13 @@ package fake
 import (
 	"context"
 
+	v1alpha1 "teainspace.com/ame/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	v1alpha1 "teainspace.com/ame/api/v1alpha1"
 )
 
 // FakeTasks implements TaskInterface

--- a/generated/clientset/versioned/typed/ame/v1alpha1/task.go
+++ b/generated/clientset/versioned/typed/ame/v1alpha1/task.go
@@ -23,11 +23,11 @@ import (
 	scheme "teainspace.com/ame/generated/clientset/versioned/scheme"
 	"time"
 
+	v1alpha1 "teainspace.com/ame/api/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	v1alpha1 "teainspace.com/ame/api/v1alpha1"
 )
 
 // TasksGetter has a method to return a TaskInterface.

--- a/server/cmd/task.pb.go
+++ b/server/cmd/task.pb.go
@@ -4,6 +4,7 @@
 package task
 
 import (
+	v1alpha1 "teainspace.com/ame/api/v1alpha1"
 	context "context"
 	fmt "fmt"
 	proto "github.com/golang/protobuf/proto"
@@ -14,7 +15,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	math "math"
 	math_bits "math/bits"
-	v1alpha1 "teainspace.com/ame/api/v1alpha1"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/server/cmd/task_server.go
+++ b/server/cmd/task_server.go
@@ -21,8 +21,8 @@ func NewTaskServer(client clientset.Interface) TaskServer {
 	return TaskServer{client}
 }
 
-func Run(cfg *rest.Config, port int) (net.Listener, func() error, error) {
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+func Run(cfg *rest.Config, port string) (net.Listener, func() error, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
 	if err != nil {
 		return listener, func() error { return nil }, err
 	}
@@ -56,7 +56,6 @@ func (s TaskServer) GetTask(ctx context.Context, taskGetRequest *TaskGetRequest)
 }
 
 func (s TaskServer) Check(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error) {
-	fmt.Println("got a check request")
 	return &HealthCheckResponse{
 		Status: HealthCheckResponse_SERVING,
 	}, nil

--- a/server/server.go
+++ b/server/server.go
@@ -1,20 +1,32 @@
 package main
 
 import (
-	"fmt"
+	"os"
 
 	"k8s.io/client-go/rest"
-	"teainspace.com/ame/server/cmd"
+	task "teainspace.com/ame/server/cmd"
 )
+
+const (
+	AME_SERVER_PORT_ENV_VAR_KEY = "AME_SERVER_PORT"
+	AME_SEVER_DEFAULT_PORT      = "3342"
+)
+
+func serverPort() string {
+	ameServerPort := os.Getenv(AME_SERVER_PORT_ENV_VAR_KEY)
+	if ameServerPort == "" {
+		ameServerPort = AME_SEVER_DEFAULT_PORT
+	}
+
+	return ameServerPort
+}
 
 func main() {
 	inclusterConfig, err := rest.InClusterConfig()
 	if err != nil {
-		// panic(err)
-		fmt.Println(err)
+		panic(err)
 	}
-
-	_, serve, err := task.Run(inclusterConfig, 3000)
+	_, serve, err := task.Run(inclusterConfig, serverPort())
 	if err != nil {
 		panic(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPortConfiguration(t *testing.T) {
+	portEnvVarTests := []struct {
+		in  string
+		out string
+	}{
+		{"3424", "3424"},             // Set the env variable to a non-default port
+		{"", AME_SEVER_DEFAULT_PORT}, // Leave the env variable empty and use the default port
+		{"dfkeijd", "dfkeijd"},       // Provide malformed input and expected that input to be used
+	}
+	// Using the malformed input is important as the user should see the server fail when providing a
+	// bad configuration. If the server and fell back to the default config it would look like everything
+	// was fine.
+
+	for _, tt := range portEnvVarTests {
+		t.Run(tt.in, func(t *testing.T) {
+			os.Setenv(AME_SERVER_PORT_ENV_VAR_KEY, tt.in)
+			assert.Equal(t, tt.out, serverPort())
+		})
+	}
+
+	os.Setenv(AME_SERVER_PORT_ENV_VAR_KEY, "")
+}


### PR DESCRIPTION
Issue: 20

To make the server flexible it is important that it is configurable via
ennvironment variables.
Therefore this commit makes the port it listens on configurable via an
environment variable. A configmap and accompanying pod configuration has
been implemented aswell showing how to configure the server in a k8s
deployment.
