### PR TITLE
Implement support for a project configuration file

### DIFF
--- a/cmd/ame/cmd/create.go
+++ b/cmd/ame/cmd/create.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"log"
+	"os"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"teainspace.com/ame/api/v1alpha1"
+	"teainspace.com/ame/internal/ameproject"
+)
+
+func attachCreate(rootCmd *cobra.Command) *cobra.Command {
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "create",
+		Short: "short desp",
+		Long:  "Long desp",
+		Run:   createProjectFile,
+	})
+
+	return rootCmd
+}
+
+func getDirectoryName() string {
+	wd, err := os.Getwd()
+	if err == nil {
+		return ameproject.ProjectNameFromDir(wd)
+	}
+	return ""
+}
+
+func createProjectFile(cmd *cobra.Command, args []string) {
+	qs, err := genQuestions(args)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	cfg := &struct {
+		ProjectName string
+		TaskName    string
+		Command     string
+	}{}
+	err = survey.Ask(qs, cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fBuilder := ameproject.NewProjectFileBuilder()
+	fBuilder.SetProjectName(cfg.ProjectName)
+	fBuilder.AddTaskSpecs(ameproject.TaskSpecs{
+		ameproject.TaskSpecName(cfg.TaskName): &v1alpha1.TaskSpec{
+			RunCommand: cfg.Command,
+			ProjectId:  cfg.ProjectName,
+		},
+	})
+
+	err = ameproject.WriteToProjectFile("./", fBuilder.Build())
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func genQuestions(args []string) ([]*survey.Question, error) {
+	qs := []*survey.Question{
+		{
+			Name:     "TaskName",
+			Prompt:   &survey.Input{Message: "Task name:"},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "Command",
+			Prompt:   &survey.Input{Message: "Command:"},
+			Validate: survey.Required,
+		},
+	}
+
+	ok, err := ameproject.ValidProjectCfgExists(".")
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		qs = append([]*survey.Question{
+			{
+				Name: "ProjectName",
+				Prompt: &survey.Input{
+					Message: "Project name:", Default: getDirectoryName(),
+					Help: "The project name is used to uniquely identify the context required by tasks for this project.",
+				},
+				Validate: survey.Required,
+			},
+		}, qs...)
+	}
+
+	// TODO: get rid of this hack when rearranging the CLI.
+	if len(args) == 1 {
+		qs[2].Prompt = &survey.Input{Message: "Command:", Default: args[0]}
+	}
+	return qs, nil
+}

--- a/cmd/ame/cmd/root.go
+++ b/cmd/ame/cmd/root.go
@@ -12,7 +12,7 @@ func newRootCmdWithSubCmds() *cobra.Command {
 }
 
 func attachSubCommands(rootCmd *cobra.Command) *cobra.Command {
-	return attachSetup(attachRun(rootCmd))
+	return attachCreate(attachSetup(attachRun(rootCmd)))
 }
 
 func Execute() {

--- a/cmd/ame/cmd/run.go
+++ b/cmd/ame/cmd/run.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -28,8 +31,34 @@ func attachRun(rootCmd *cobra.Command) *cobra.Command {
 	return rootCmd
 }
 
+func shouldAProjectBeCreated() (bool, error) {
+	ok, err := ameproject.ValidProjectCfgExists(".")
+	if err != nil {
+		return false, err
+	}
+
+	if !ok {
+		var resp bool
+		err = survey.AskOne(&survey.Confirm{
+			Message: "Would you like to setup a project?",
+			Default: true,
+		}, &resp)
+
+		if err != nil {
+			return false, err
+		}
+
+		return resp, nil
+	}
+
+	return false, nil
+}
+
 // TODO: current have to pass run command in quotes "python train.py"
 // TODO: handle errors gracefully in the CLI
+// TODO: CLI seems to just finish early and pretent everything suceeded if a pod is pending, trying running a lot of
+// pods after each other to reproduce this.
+// TODO: Why does survey not block when being run during tests?
 
 func runTask(cmd *cobra.Command, args []string) {
 	ctx := context.Background()
@@ -39,7 +68,15 @@ func runTask(cmd *cobra.Command, args []string) {
 		log.Fatalln("It looks like no CLI configuration is present, got error: ", err)
 	}
 
-	fmt.Println("Your task will be executed!", args[0])
+	ok, err := shouldAProjectBeCreated()
+	if err != nil {
+		// TODO: determine how to check for survey EOF so we don't break TestCanDownloadArtifacts when failing on this error.
+		log.Println(err)
+	}
+
+	if ok {
+		createProjectFile(cmd, args)
+	}
 
 	// TODO: move grpc setup to a library package.
 	var opts []grpc.DialOption
@@ -60,13 +97,24 @@ func runTask(cmd *cobra.Command, args []string) {
 
 	// TODO: handle authtorization the context elegantly.
 	ctx = auth.AuthorarizeCtx(ctx, cfg.AuthToken)
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
+	fmt.Println()
+	s.Suffix = " Uploading project: " + p.Name
+	s.Start()
 
 	projectTask, err := p.UploadAndRun(ctx, v1alpha1.NewTask(args[0], p.Name))
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	s.Suffix = " Preparing execution environment"
+
 	err = p.ProcessTaskLogs(ctx, projectTask, func(le *task.LogEntry) error {
+		if s.Active() {
+			s.Stop()
+			fmt.Println("Your task will be executed!", args[0])
+		}
+
 		fmt.Println(le.Content)
 		return nil
 	})

--- a/config/server/server.yaml
+++ b/config/server/server.yaml
@@ -41,10 +41,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 500Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 250Mi
         env:
           - name: AME_SERVER_PORT
             valueFrom:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.9
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.1
+	github.com/briandowns/spinner v1.19.0
 	github.com/brianvoe/gofakeit/v6 v6.16.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
@@ -24,6 +25,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
+	go.uber.org/zap v1.21.0
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	google.golang.org/grpc v1.48.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -60,6 +62,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
+	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
@@ -105,7 +108,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/net v0.0.0-20220708220712-1185a9018129 // indirect
 	golang.org/x/oauth2 v0.0.0-20220718184931-c8730f7fcb92 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
+github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/brianvoe/gofakeit/v6 v6.16.0 h1:EelCqtfArd8ppJ0z+TpOxXH8sVWNPBadPNdCDSMMw7k=
 github.com/brianvoe/gofakeit/v6 v6.16.0/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
@@ -220,6 +222,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -466,10 +470,12 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -852,6 +858,7 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/ameproject/config.go
+++ b/internal/ameproject/config.go
@@ -11,14 +11,24 @@ import (
 
 const AmeProjectFileName = "ame.yaml"
 
-type TaskSpecs map[string]*v1alpha1.TaskSpec
+// A TaskSpecName is how we identify individual TaskSpecs created
+// by the user in the AME project file. This will be how a user
+// identifies a task specification.
+type TaskSpecName string
 
+// A TaskSpecs instance maps TaskSpecNames to TaskSpecs.
+type TaskSpecs map[TaskSpecName]*v1alpha1.TaskSpec
+
+// A ProjectFileCfg encapsulats all of the configuration in an
+// AME project file.
 type ProjectFileCfg struct {
 	DefaultTask string    `yaml:"defaultTask,omitempty"`
 	ProjectName string    `yaml:"projectname"`
 	Specs       TaskSpecs `yaml:"tasks"`
 }
 
+// A ProjectFileBuilder allows for procedural creation of a ProjectFileCfg,
+// by having individual methods for each aspect of the AME project file configuration.
 type ProjectFileBuilder struct {
 	fileCfg *ProjectFileCfg
 }
@@ -63,7 +73,30 @@ func (b ProjectFileBuilder) Build() *ProjectFileCfg {
 	return b.fileCfg
 }
 
-func WriteProjectFile(dir string, cfg *ProjectFileCfg) error {
+// WriteToProjectFile saves a ProjectFileCfg to a directory, using AmeProjectFileName as the file name.
+// If there is an existing AME project file, the two configurations are merged, where the values in cfg
+// take precedence over existing values.
+// An error is returned if something goes wrong.
+func WriteToProjectFile(dir string, cfg *ProjectFileCfg) error {
+	ok, err := ValidProjectCfgExists(dir)
+	if err != nil {
+		return err
+	}
+
+	if ok {
+		existingCfg, err := ReadProjectFile(dir)
+		if err != nil {
+			return err
+		}
+
+		for key := range cfg.Specs {
+			existingCfg.Specs[key] = cfg.Specs[key]
+		}
+
+		cfg.Specs = existingCfg.Specs
+		cfg.ProjectName = existingCfg.ProjectName
+	}
+
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return err
@@ -74,6 +107,11 @@ func WriteProjectFile(dir string, cfg *ProjectFileCfg) error {
 }
 
 // TODO: support all yaml file extensions
+
+// ReadProjectFile attempts to generated a ProjectFileCfg from a file in dir with AmeProjectFileName as the name.
+// The structure of the file is validated, but the values are not.
+// A pointer to the generated configuration is returned if no errors are encountered.
+// If an error is encountered a nil pointer is returned a long with the error.
 func ReadProjectFile(dir string) (*ProjectFileCfg, error) {
 	data, err := os.ReadFile(path.Join(dir, AmeProjectFileName))
 	if err != nil {
@@ -94,4 +132,24 @@ func ReadProjectFile(dir string) (*ProjectFileCfg, error) {
 		ProjectName: out.ProjectName,
 		Specs:       out.Specs,
 	}, nil
+}
+
+// ValidProjectCfgExists determines is a valid AME project file exists in dir.
+// A bool is returned indicating if that is the case.
+// If an error is encountered it is assumed that no valid file was found.
+func ValidProjectCfgExists(dir string) (bool, error) {
+	cfg, err := ReadProjectFile(dir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	if cfg.ProjectName == "" {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/internal/ameproject/project.go
+++ b/internal/ameproject/project.go
@@ -71,7 +71,8 @@ func (p *Project) UploadTaskForProject(ctx context.Context, t *v1alpha1.Task) (*
 }
 
 func (p *Project) UploadProject(ctx context.Context) error {
-	t, err := filescanner.TarDirectory(p.Directory, []string{})
+	// There is no need to upload the ame project file, so it is filtered out.
+	t, err := filescanner.TarDirectory(p.Directory, []string{AmeProjectFileName})
 	if err != nil {
 		return err
 	}

--- a/server/logs/task-logger_test.go
+++ b/server/logs/task-logger_test.go
@@ -154,6 +154,7 @@ func TestLogStreamFailsAfterTimeout(t *testing.T) {
 	}
 }
 
+// TODO: This test is flaky, we might be running out of memory, as both tasks will request 3GB of ram.
 func TestCanStreamLogForMultipleTasksAtOnce(t *testing.T) {
 	_, err := testenv.SetupCluster(ctx, testCfg)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"os"
 
 	"k8s.io/client-go/rest"
@@ -33,8 +35,13 @@ func main() {
 		panic(err)
 	}
 
+	log.Println("serving")
+
 	err = serve()
 	if err != nil {
-		panic(err)
+		fmt.Println("Got error")
+		log.Fatalln(err)
 	}
+
+	log.Println("Finished serving")
 }

--- a/test_data/test_projects/artifacts/generated/myartifact.txt
+++ b/test_data/test_projects/artifacts/generated/myartifact.txt
@@ -1,1 +1,0 @@
-artifactContents


### PR DESCRIPTION
Issue: 36

In order to store project configuration the CLI needs to support
creating and editing an in project file.

Therefore this commit implements support for the CLI to generate an
ame.yaml file inside the project directory. As well as adding multiple
task specifications to that file.
