### PR TITLE
Add option to override image in task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,12 +243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
 name = "controller"
 version = "0.1.0"
 dependencies = [
@@ -398,13 +392,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "doctest"
-version = "0.1.0"
-dependencies = [
- "tz-rs",
 ]
 
 [[package]]
@@ -2085,15 +2072,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["controller", "service", "doctest"]
+members = ["controller", "service"]

--- a/controller/src/snapshots/controller__manager__test__task_can_override_workflow_image.snap
+++ b/controller/src/snapshots/controller__manager__test__task_can_override_workflow_image.snap
@@ -1,0 +1,116 @@
+---
+source: controller/src/manager.rs
+expression: "&wf"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  labels:
+    task: training
+  name: training
+  ownerReferences:
+    - apiVersion: ""
+      kind: ""
+      name: ""
+      uid: ""
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      metadata: ~
+      steps:
+        - - name: setup
+            inline:
+              name: setup
+              metadata:
+                labels:
+                  ame-task: training
+                annotations: ~
+              steps: ~
+              securitycontext:
+                fsGroup: 2000
+                runAsUser: 1001
+              script:
+                command:
+                  - bash
+                env:
+                  - name: AWS_ACCESS_KEY_ID
+                    value: minio
+                  - name: AWS_SECRET_ACCESS_KEY
+                    value: minio123
+                  - name: MINIO_URL
+                    value: "http://ame-minio.ame-system.svc.cluster.local:9000"
+                  - name: TASK_DIRECTORY
+                    value: ameprojectstorage/myproject
+                  - name: PIPENV_YES
+                    value: "1"
+                image: "ghcr.io/teainspace/ame/ame-executor:0.0.3"
+                name: ""
+                volumeMounts:
+                  - mountPath: /project
+                    name: training-volume
+                source: "\n                       s3cmd --no-ssl --region us-east-1 --host=$MINIO_URL --host-bucket=$MINIO_URL get --recursive s3://$TASK_DIRECTORY ./\n                       echo \"0\" >> exit.status\n                        "
+              podspecpatch: ~
+        - - name: main
+            inline:
+              name: training
+              metadata:
+                labels:
+                  ame-task: training
+                annotations: ~
+              steps: ~
+              securitycontext:
+                fsGroup: 2000
+                runAsUser: 1001
+              script:
+                command:
+                  - bash
+                env:
+                  - name: AWS_ACCESS_KEY_ID
+                    value: minio
+                  - name: AWS_SECRET_ACCESS_KEY
+                    value: minio123
+                  - name: MINIO_URL
+                    value: "http://ame-minio.ame-system.svc.cluster.local:9000"
+                  - name: TASK_DIRECTORY
+                    value: ameprojectstorage/myproject
+                  - name: PIPENV_YES
+                    value: "1"
+                  - name: KEY1
+                    valueFrom:
+                      secretKeyRef:
+                        key: secret
+                        name: secret1
+                  - name: KEY2
+                    valueFrom:
+                      secretKeyRef:
+                        key: secret
+                        name: secret2
+                  - name: VAR1
+                    value: val1
+                  - name: VAR2
+                    value: val2
+                image: very-different-image
+                name: ""
+                volumeMounts:
+                  - mountPath: /project
+                    name: training-volume
+                source: "\n          export TASK_DIRECTORY=ameprojectstorage/myproject\n\n          cd \"./myproject\" \n\n          set -e # It is important that the workflow exits with an error code if execute or save_artifacts fails, so AME can take action based on that information.\n\n          execute \"python train.py\" \n          \n          save_artifacts \"ameprojectstorage/training/artifacts/\"\n\n          echo \"0\" >> exit.status\n            "
+              podspecpatch: "{\"containers\":[{\"name\":\"main\", \"resources\":{\"limits\":null}}]}"
+      securitycontext: ~
+      script: ~
+      podspecpatch: ~
+  imagepullsecrets: ~
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: training-volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
+  volumes: ~
+

--- a/justfile
+++ b/justfile
@@ -102,3 +102,5 @@ remove_server:
 describe_server:
   kubectl describe pod -l app=ame-server -n {{TARGET_NAMESPACE}}
 
+install_commit_template:
+  git config commit.template ./.git_commit_message_template

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -34,6 +34,9 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              image:
+                nullable: true
+                type: string
               pipeline:
                 items:
                   properties:
@@ -154,12 +157,11 @@ spec:
                 - Pending
                 - Failed
                 - Succeeded
+                nullable: true
                 type: string
               reason:
                 nullable: true
                 type: string
-            required:
-            - phase
             type: object
         required:
         - spec

--- a/manifests/server/local/kustomization.yaml
+++ b/manifests/server/local/kustomization.yaml
@@ -5,6 +5,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: ame-server
-  newName: main:39431/ame-server
+  newName: main:34713/ame-server
   newTag: latest
 namespace: ame-system

--- a/service/task.proto
+++ b/service/task.proto
@@ -9,6 +9,7 @@ message TaskIdentifier {
 message Task {
   string projectid = 1;
   string command = 2;
+  optional string image = 3;
 }
 
 message Empty {


### PR DESCRIPTION
Issue: #84

The user should be able to override default images to support other usecases.
Therefore, this commit exposes an image field in the Task config which then overrides the image used in the Workflow that handles executing the Task.