### PR TITLE
Implement model deployment/inference with Mlflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.8",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1304eab461cf02bd70b083ed8273388f9724c549b316ba3d1e213ce0e9e7fb7e"
+checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f487e40dc9daee24d8a1779df88522f159a54a980f99cfbe43db0be0bd3444a8"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
 dependencies = [
  "async-trait",
  "bytes",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecount"
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -462,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -494,7 +494,7 @@ dependencies = [
  "rand 0.8.5",
  "rstest",
  "serde",
- "serde_yaml 0.9.16",
+ "serde_yaml 0.9.17",
  "serial_test",
  "similar-asserts",
  "temp-env",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
  "encode_unicode",
  "lazy_static",
@@ -585,11 +585,12 @@ dependencies = [
  "kube",
  "predicates",
  "prometheus",
+ "reqwest",
  "schemars",
  "serde",
  "serde_json",
  "serde_tuple",
- "serde_yaml 0.9.16",
+ "serde_yaml 0.9.17",
  "serial_test",
  "similar",
  "similar-asserts",
@@ -663,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d1075c37807dcf850c379432f0df05ba52cc30f279c5cfc43cc221ce7f8579"
+checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -675,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5044281f61b27bc598f2f6647d480aed48d2bf52d6eb0b627d84c0361b17aa70"
+checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -690,15 +691,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b50bc93ba22c27b0d31128d2d130a0a6b3d267ae27ef7e4fae2167dfe8781c"
+checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e61fda7e62115119469c7b3591fd913ecca96fb766cfd3f2e2502ab7bc87a5"
+checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -707,12 +708,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.2",
+ "darling_macro 0.14.2",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -731,11 +756,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.2",
  "quote",
  "syn",
 ]
@@ -857,9 +893,9 @@ checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -1423,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
  "globset",
  "lazy_static",
@@ -1480,9 +1516,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1587,7 +1623,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.3",
  "anyhow",
  "base64 0.13.1",
  "bytecount",
@@ -1700,7 +1736,7 @@ version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1af50996adb7e1251960d278859772fa30df99879dc154d792e36832209637cb"
 dependencies = [
- "darling",
+ "darling 0.14.2",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1713,7 +1749,7 @@ version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9b312c38884a3f41d67e2f7580824b6f45d360b98497325b5630664b3a359d"
 dependencies = [
- "ahash 0.8.2",
+ "ahash 0.8.3",
  "backoff",
  "derivative",
  "futures",
@@ -1745,9 +1781,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.1+1.5.0"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",
@@ -1878,9 +1914,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minidom"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dddfe21863f8d600ed2bd1096cb9b5cd6ff984be6185cf9d563fb4a107bffc5"
+checksum = "2e9ce45d459e358790a285e7609ff5ae4cfab88b75f237e8838e62029dda397b"
 dependencies = [
  "rxml",
 ]
@@ -1938,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1995,9 +2031,9 @@ checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
@@ -2092,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "openidconnect"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87af7097640fedbe64718ac1c9b0549d72da747a3f527cd089215f96c6f691d5"
+checksum = "32a0f47b0f1499d08c4a8480c963d49c5ec77f4249c2b6869780979415f45809"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -2110,6 +2146,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "subtle",
  "thiserror",
  "url",
 ]
@@ -2282,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2316,9 +2355,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2326,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+checksum = "8bf026e2d0581559db66d837fe5242320f525d85c76283c61f4d51a1238d65ea"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2336,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+checksum = "2b27bd18aa01d91c8ed2b61ea23406a676b42d82609c6e2581fba42f0c15f17f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2349,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+checksum = "9f02b677c1859756359fc9983c2e56a0237f18624a3789528804406b7e915e5d"
 dependencies = [
  "once_cell",
  "pest",
@@ -2478,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -2698,11 +2737,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2734,6 +2773,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -2843,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -2857,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -2983,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "7c4437699b6d34972de58652c68b98cb5b53a4199ab126db8e20ec8ded29a721"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2996,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3085,6 +3125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_tuple"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3167,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling 0.13.4",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b5b431e8907b50339b51223b97d102db8d987ced36f6e4d03621db9316c834"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3363,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3471,9 +3542,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3571,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -3827,9 +3898,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -4015,6 +4086,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,9 +4129,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",
@@ -4108,45 +4192,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -37,6 +37,7 @@ humantime = "2.1.0"
 k8s-openapi = { version = "0.16.0", features = ["v1_23", "schemars" ] }
 kube = { version = "0.76.0", features = ["runtime", "client", "derive"] }
 prometheus = "0.13.3"
+reqwest = { version = "0.11.14", features = ["json"] }
 schemars = "0.8.11"
 serde = {version = "1.0.147", features = ["derive"]}
 serde_json = "1.0.87"

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -42,6 +42,15 @@ pub enum Error {
 
     #[error("Environment variable was not present: {0}")]
     MissingEnvVariable(#[from] VarError),
+
+    #[error("No model deployment was found")]
+    MissingDeployment(),
+
+    #[error("No Mlfow URL was found")]
+    MissingMlflowUrl(),
+
+    #[error("Request error: {0}")]
+    RequestError(#[from] reqwest::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -57,3 +66,6 @@ pub use argo::WorkflowPhase;
 
 pub mod project;
 pub mod project_source;
+pub use project_source::GitProjectSource;
+pub use project_source::ProjectSource;
+pub use project_source::ProjectSourceSpec;

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,3 +1,4 @@
+use controller::project::ProjectCtrlCfg;
 use controller::*;
 use controller::{manager::TaskControllerConfig, project_source::ProjectSrcCtrlCfg};
 use envconfig::Envconfig;
@@ -6,15 +7,18 @@ use envconfig::Envconfig;
 async fn main() -> Result<()> {
     let task_ctrl_cfg = TaskControllerConfig::init_from_env().unwrap();
     let project_src_ctrl_cfg = ProjectSrcCtrlCfg::init_from_env().unwrap();
+    let project_ctrl_cfg = ProjectCtrlCfg::from_env().unwrap();
 
     // Start kubernetes controller
     let task_controller = manager::start_task_controller(task_ctrl_cfg).await;
     let projectsrc_controller =
         project_source::start_project_source_controller(project_src_ctrl_cfg).await;
+    let project_controller = project::start_project_controller(project_ctrl_cfg).await;
 
     tokio::select! {
-        _ = task_controller=> println!("controller exited"),
-        _ = projectsrc_controller => println!("controller exited"),
+        _ = task_controller=> println!("task controller exited"),
+        _ = projectsrc_controller => println!("project source controller exited"),
+        _ = project_controller=> println!("project controller exited"),
     }
 
     Ok(())

--- a/controller/src/project.rs
+++ b/controller/src/project.rs
@@ -1,9 +1,38 @@
-use crate::TaskSpec;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
-use kube::CustomResource;
+use crate::{manager, Error, Result, TaskSpec};
+
+use futures::{future::BoxFuture, FutureExt, StreamExt};
+use k8s_openapi::{
+    api::{
+        apps::v1::{Deployment, DeploymentSpec},
+        core::v1::{
+            Container, ContainerPort, EnvVar, HTTPGetAction, PodSpec, PodTemplateSpec, Probe,
+            ResourceRequirements, Service, ServicePort, ServiceSpec,
+        },
+        networking::v1::{
+            HTTPIngressPath, HTTPIngressRuleValue, Ingress, IngressBackend, IngressRule,
+            IngressServiceBackend, IngressSpec, IngressTLS, ServiceBackendPort,
+        },
+    },
+    apimachinery::pkg::{
+        apis::meta::v1::{LabelSelector, OwnerReference, Time},
+        util::intstr::IntOrString,
+    },
+};
+use kube::{
+    api::{ListParams, Patch, PatchParams},
+    core::ObjectMeta,
+    runtime::{controller::Action, Controller},
+    Api, Client, CustomResource, Resource, ResourceExt,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
 #[kube(
@@ -20,6 +49,9 @@ pub struct ProjectSpec {
     id: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    models: Option<Vec<Model>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     tasks: Option<Vec<TaskSpec>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -27,7 +59,64 @@ pub struct ProjectSpec {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq, Eq, Default)]
-pub struct ProjectStatus {}
+pub struct ProjectStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    models: Option<Vec<ModelStatus>>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Model {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model_type: Option<ModelType>,
+
+    training: TrainingCfg,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deployment: Option<ModelDeployment>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
+pub struct TrainingCfg {
+    task: TaskSpec,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schedule: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, Default)]
+pub struct ModelDeployment {
+    deploy: bool,
+    auto_train: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resources: Option<ResourceRequirements>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    replicas: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ingress: Option<Ingress>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ingress_annotations: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enable_tls: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub enum ModelType {
+    Mlflow,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelStatus {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    latest_model_version: Option<Time>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_trained: Option<Time>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_deployed: Option<Time>,
+}
 
 impl Project {
     pub fn add_owner_reference(&mut self, owner_reference: OwnerReference) -> &mut Project {
@@ -37,5 +126,517 @@ impl Project {
         };
 
         self
+    }
+
+    pub fn add_annotation(&mut self, key: String, val: String) -> &mut Project {
+        let mut annotations = if let Some(annotations) = self.metadata.annotations.clone() {
+            annotations
+        } else {
+            BTreeMap::new()
+        };
+
+        annotations.insert(key, val);
+
+        self.metadata.annotations = Some(annotations);
+        self
+    }
+}
+
+fn add_owner_reference(mut metadata: ObjectMeta, owner_reference: OwnerReference) -> ObjectMeta {
+    match &mut metadata.owner_references {
+        Some(refs) => refs.push(owner_reference),
+        None => metadata.owner_references = Some(vec![owner_reference]),
+    };
+
+    metadata
+}
+
+impl Model {
+    fn labels(&self) -> BTreeMap<String, String> {
+        let mut labels: BTreeMap<String, String> = BTreeMap::new();
+        labels.insert("ame-model".to_string(), self.name.clone());
+        labels
+    }
+
+    fn object_metadata(&self) -> ObjectMeta {
+        ObjectMeta {
+            name: Some(self.name.clone()),
+            labels: Some(self.labels()),
+            ..ObjectMeta::default()
+        }
+    }
+
+    fn generate_model_ingress(&self, ctrl_cfg: &ProjectCtrlCfg) -> Result<Ingress> {
+        let Some(model_deployment) = self.deployment.clone() else {
+            return Err(Error::MissingDeployment())
+        };
+
+        let mut ingress_annotations = ctrl_cfg
+            .model_ingress_annotations
+            .clone()
+            .unwrap_or(BTreeMap::<String, String>::new());
+
+        if let Some(mut annotations) = model_deployment.ingress_annotations {
+            ingress_annotations.append(&mut annotations);
+        }
+
+        let metadata = ObjectMeta {
+            name: Some(self.name.clone()),
+            labels: Some(self.labels()),
+            annotations: Some(ingress_annotations),
+            ..ObjectMeta::default()
+        };
+
+        let tls: Option<Vec<IngressTLS>> = match model_deployment.enable_tls {
+            Some(true) | None => Some(vec![IngressTLS {
+                hosts: Some(vec![ctrl_cfg
+                    .clone()
+                    .model_ingress_host
+                    .unwrap_or("".to_string())]),
+                secret_name: Some(format!("{}-tls", self.name)),
+            }]),
+            _ => None,
+        };
+
+        Ok(Ingress {
+            metadata,
+            spec: Some(IngressSpec {
+                ingress_class_name: Some("nginx".to_string()),
+                rules: Some(vec![IngressRule {
+                    host: Some(
+                        ctrl_cfg
+                            .clone()
+                            .model_ingress_host
+                            .unwrap_or("".to_string()),
+                    ),
+                    http: Some(HTTPIngressRuleValue {
+                        paths: vec![HTTPIngressPath {
+                            backend: IngressBackend {
+                                service: Some(IngressServiceBackend {
+                                    name: self.name.clone(),
+                                    port: Some(ServiceBackendPort {
+                                        number: Some(5000),
+                                        name: None,
+                                    }),
+                                }),
+                                ..IngressBackend::default()
+                            },
+                            path_type: "ImplementationSpecific".to_string(),
+                            path: None,
+                        }],
+                    }),
+                }]),
+                tls,
+                ..IngressSpec::default()
+            }),
+            ..Ingress::default()
+        })
+    }
+
+    fn generate_model_service(&self, _ctrl_cfg: &ProjectCtrlCfg) -> Result<Service> {
+        let Some(_model_deployment) = self.deployment.clone() else {
+            return Err(Error::MissingDeployment())
+        };
+
+        Ok(Service {
+            metadata: self.object_metadata(),
+            spec: Some(ServiceSpec {
+                selector: Some(self.labels()),
+                ports: Some(vec![ServicePort {
+                    port: 5000,
+                    ..ServicePort::default()
+                }]),
+                ..ServiceSpec::default()
+            }),
+            ..Service::default()
+        })
+    }
+
+    async fn get_latest_model_version(
+        &self,
+        ctrl_cfg: &ProjectCtrlCfg,
+    ) -> Result<MlflowModelVersion> {
+        let Some(ref mlflow_url) = ctrl_cfg.mlflow_url else {
+            return Err(Error::MissingMlflowUrl());
+        };
+
+        let Some(model_version) = ({
+            let mut body = HashMap::new();
+            body.insert("name", self.name.clone());
+            let client = reqwest::Client::new();
+            let MlflowModelVersionRes {model_versions } = client
+                .post(format!(
+                    "{mlflow_url}/api/2.0/mlflow/registered-models/get-latest-versions"
+                ))
+                .json(&body)
+                .send()
+                .await?
+                .json()
+                .await?;
+
+            model_versions
+                .into_iter()
+                .max_by_key(|v| v.creation_timestamp)
+        }) else {
+            return Err(Error::MissingMlflowUrl());
+        };
+
+        Ok(model_version)
+    }
+
+    async fn generate_model_deployment(
+        &self,
+        ctrl_cfg: &ProjectCtrlCfg,
+        model_source: String,
+    ) -> Result<Deployment> {
+        let Some(model_deployment) = self.deployment.clone() else {
+            return Err(Error::MissingDeployment());
+        };
+
+        let labels = self.labels();
+
+        let server_port = 5000;
+
+        Ok(Deployment {
+            metadata: ObjectMeta {
+                name: Some(self.name.clone()),
+                labels: Some(labels.clone()),
+                ..ObjectMeta::default()
+            },
+            spec: Some(DeploymentSpec {
+                selector: LabelSelector {
+                    match_labels: Some(labels.clone()),
+                    ..LabelSelector::default()
+                },
+                replicas: Some(model_deployment.replicas.unwrap_or(1)),
+                template: PodTemplateSpec {
+                    metadata: Some(ObjectMeta {
+                        labels: Some(labels),
+                        ..ObjectMeta::default()
+                    }),
+                    spec: Some(PodSpec {
+                        containers: vec![Container {
+                            security_context: Some(serde_json::from_value(json!({
+                            "runAsUser": 1001,
+                            "fsGroup": 2000
+                            }))?),
+                            name: "main".to_string(),
+                            image: Some(
+                                model_deployment
+                                    .image
+                                    .unwrap_or(ctrl_cfg.clone().deployment_image),
+                            ),
+                            command: Some(vec!["/bin/bash".to_string()]),
+                            args: Some(vec![
+                                "-c".to_string(),
+                                format!("export PATH=$HOME/.pyenv/bin:$PATH; mlflow models serve -m {model_source} --host 0.0.0.0"),
+                            ]),
+                            resources: model_deployment.resources,
+                            env: Some(vec![EnvVar {
+                                name: "MLFLOW_TRACKING_URI".to_string(),
+                                value: Some(
+                                    "http://mlflow.default.svc.cluster.local:5000".to_string(),
+                                ),
+                                ..EnvVar::default()
+                            }]),
+                            ports: Some(vec![ContainerPort {
+                                container_port: server_port,
+                                ..ContainerPort::default()
+                            }]),
+                            readiness_probe: Some(Probe {
+                                http_get: Some(HTTPGetAction {
+                                    port: IntOrString::Int(server_port),
+                                    path: Some("/health".to_string()),
+                                    ..HTTPGetAction::default()
+                                }),
+                                ..Probe::default()
+                            }),
+                            ..Container::default()
+                        }],
+                        ..PodSpec::default()
+                    }),
+                },
+                ..DeploymentSpec::default()
+            }),
+            ..Deployment::default()
+        })
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
+pub struct ProjectCtrlCfg {
+    namespace: String,
+    deployment_image: String,
+    model_deployment_ingress: Option<Ingress>,
+    model_ingress_annotations: Option<BTreeMap<String, String>>,
+    model_ingress_host: Option<String>,
+    mlflow_url: Option<String>,
+}
+
+impl ProjectCtrlCfg {
+    pub fn from_env() -> Result<Self> {
+        let prefix = "AME";
+
+        Ok(ProjectCtrlCfg {
+            namespace: std::env::var(format!("{prefix}_NAMESPACE"))?,
+            deployment_image: std::env::var("EXECUTOR_IMAGE")?,
+            model_deployment_ingress: serde_yaml::from_str(
+                &std::env::var(format!("{prefix}_MODEL_DEPLOYMENT_INGRESS"))
+                    .unwrap_or("".to_string()),
+            )
+            .ok(),
+            model_ingress_annotations: Some(BTreeMap::new()),
+            model_ingress_host: std::env::var(format!("{prefix}_MODEL_INGRESS_HOST")).ok(),
+            mlflow_url: std::env::var(format!("{prefix}_MLFLOW_URL")).ok(),
+        })
+    }
+}
+
+struct Context {
+    client: Client,
+    config: ProjectCtrlCfg,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
+struct MlflowModelVersionRes {
+    model_versions: Vec<MlflowModelVersion>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
+struct MlflowModelVersion {
+    name: String,
+    version: String,
+    current_stage: String,
+    creation_timestamp: i64,
+    source: String,
+    run_id: String,
+}
+
+async fn reconcile(project: Arc<Project>, ctx: Arc<Context>) -> Result<Action> {
+    println!("reconciling project srcs");
+    let _projects = Api::<Project>::namespaced(ctx.client.clone(), &ctx.config.namespace);
+    let deployments = Api::<Deployment>::namespaced(ctx.client.clone(), &ctx.config.namespace);
+    let ingresses = Api::<Ingress>::namespaced(ctx.client.clone(), &ctx.config.namespace);
+    let services = Api::<Service>::namespaced(ctx.client.clone(), &ctx.config.namespace);
+    let tasks_cli = Api::<manager::Task>::namespaced(ctx.client.clone(), &ctx.config.namespace);
+    let ctrl_cfg = ctx.config.clone();
+    let oref = if let Some(refe) = project.controller_owner_ref(&()) {
+        refe
+    } else {
+        OwnerReference::default()
+    };
+
+    if let Some(models) = project.spec.clone().models {
+        for model in models {
+            let model_version = model.get_latest_model_version(&ctrl_cfg).await;
+
+            if let Some(ModelDeployment {
+                auto_train: true,
+                deploy: true,
+                ..
+            }) = model.clone().deployment
+            {
+                println!("creating autotrain task {model_version:?}");
+                if model_version.is_err() {
+                    let task_ref = model.training.task.task_ref.clone().unwrap();
+
+                    let project_spec = project.spec.clone();
+                    let tasks = project_spec.tasks.unwrap();
+                    let mut task_spec = tasks
+                        .iter()
+                        .find(|t| t.name.clone().unwrap() == task_ref)
+                        .unwrap()
+                        .to_owned();
+
+                    let medata = project.metadata.clone();
+
+                    let annotations = medata.annotations.unwrap();
+
+                    let repo = annotations.get("gitrepository").unwrap();
+
+                    task_spec.source = Some(manager::ProjectSource {
+                        gitrepository: Some(repo.to_owned()),
+                        ..manager::ProjectSource::default()
+                    });
+
+                    let metadata = ObjectMeta {
+                        name: Some(model.name.clone()),
+                        ..ObjectMeta::default()
+                    };
+
+                    let task = manager::Task {
+                        metadata: add_owner_reference(metadata, oref.clone()),
+                        spec: task_spec.clone(),
+                        status: None,
+                    };
+
+                    tasks_cli
+                        .patch(
+                            &task.name_any(),
+                            &PatchParams::apply("ame"),
+                            &Patch::Apply(&task),
+                        )
+                        .await?;
+                }
+            };
+
+            let mut deployment = model
+                .generate_model_deployment(&ctrl_cfg, model_version?.source)
+                .await?;
+            let mut service = model.generate_model_service(&ctrl_cfg)?;
+            let mut ingress = model.generate_model_ingress(&ctrl_cfg)?;
+            let pp = PatchParams::apply("ame");
+
+            deployment.metadata = add_owner_reference(deployment.metadata, oref.clone());
+            service.metadata = add_owner_reference(service.metadata, oref.clone());
+            ingress.metadata = add_owner_reference(ingress.metadata, oref.clone());
+
+            deployments
+                .patch(&deployment.name_any(), &pp, &Patch::Apply(&deployment))
+                .await?;
+            services
+                .patch(&service.name_any(), &pp, &Patch::Apply(&service))
+                .await?;
+            ingresses
+                .patch(&ingress.name_any(), &pp, &Patch::Apply(&ingress))
+                .await?;
+        }
+    }
+
+    Ok(Action::requeue(Duration::from_secs(300)))
+}
+
+fn error_policy(src: Arc<Project>, error: &Error, _ctx: Arc<Context>) -> Action {
+    println!("error: {}, for project: {}", error, src.name_any());
+    Action::requeue(Duration::from_secs(5))
+}
+
+pub async fn start_project_controller(config: ProjectCtrlCfg) -> BoxFuture<'static, ()> {
+    let client = Client::try_default().await.expect("Failed to create a K8S client, is the controller running in an environment with access to cluster credentials?");
+    let context = Arc::new(Context {
+        client: client.clone(),
+        config,
+    });
+
+    let projects = Api::<Project>::namespaced(client.clone(), &context.config.namespace);
+    projects
+        .list(&ListParams::default())
+        .await
+        .expect("Is the CRD installed?");
+
+    let services = Api::<Service>::namespaced(client.clone(), &context.config.namespace);
+    let ingresses = Api::<Ingress>::namespaced(client.clone(), &context.config.namespace);
+    let deployments = Api::<Deployment>::namespaced(client.clone(), &context.config.namespace);
+    let tasks = Api::<manager::Task>::namespaced(client, &context.config.namespace);
+
+    Controller::new(projects.clone(), ListParams::default())
+        .owns(deployments, ListParams::default())
+        .owns(services, ListParams::default())
+        .owns(ingresses, ListParams::default())
+        .owns(tasks, ListParams::default())
+        .run(reconcile, error_policy, context)
+        .filter_map(|x| async move { std::result::Result::ok(x) })
+        .for_each(|_| futures::future::ready(()))
+        .boxed()
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use serde_json::json;
+
+    use super::{Project, ProjectCtrlCfg};
+    use crate::Result;
+    use serial_test::serial;
+
+    fn test_project() -> Result<Project> {
+        Ok(serde_json::from_value(json!({
+            "apiVersion": "ame.teainspace.com/v1alpha1",
+            "kind": "Project",
+            "metadata": { "name": "test-private" },
+            "spec": {
+                "projectid": "myproject",
+                "models": [
+                {
+                    "name": "test",
+                    "training": {
+                        "task": {
+                            "taskRef": "trainingtask",
+                            "runcommand": "test",
+                            "projectid": "test",
+                        }
+                    },
+                    "deployment": {
+                        "deploy": true,
+                        "auto_train": false
+                    }
+                }
+                ]
+            }
+        }))?)
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn produces_valid_deployment() -> Result<()> {
+        let ctrl_cfg = ProjectCtrlCfg {
+            namespace: "default".to_string(),
+            deployment_image: "test_img".to_string(),
+            model_ingress_host: Some("testhost".to_string()),
+            mlflow_url: Some("mlflowurl".to_string()),
+            ..ProjectCtrlCfg::default()
+        };
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let project = test_project()?;
+
+        insta::assert_yaml_snapshot!(
+            &project.spec.models.unwrap().clone()[0]
+                .generate_model_deployment(&ctrl_cfg, "model_source".to_string())
+                .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn produces_valid_service() -> Result<()> {
+        let ctrl_cfg = ProjectCtrlCfg {
+            namespace: "default".to_string(),
+            deployment_image: "test_img".to_string(),
+            model_ingress_host: Some("testhost".to_string()),
+            ..ProjectCtrlCfg::default()
+        };
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let project = test_project()?;
+
+        insta::assert_yaml_snapshot!(
+            &project.spec.models.unwrap()[0].generate_model_service(&ctrl_cfg)?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn produces_valid_ingress() -> Result<()> {
+        let ctrl_cfg = ProjectCtrlCfg {
+            namespace: "default".to_string(),
+            deployment_image: "test_img".to_string(),
+            model_ingress_host: Some("testhost".to_string()),
+            ..ProjectCtrlCfg::default()
+        };
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let project = test_project()?;
+
+        insta::assert_yaml_snapshot!(
+            &project.spec.models.unwrap()[0].generate_model_ingress(&ctrl_cfg)?
+        );
+
+        Ok(())
     }
 }

--- a/controller/src/snapshots/controller__manager__test__task_can_have_git_src.snap
+++ b/controller/src/snapshots/controller__manager__test__task_can_have_git_src.snap
@@ -1,0 +1,137 @@
+---
+source: controller/src/manager.rs
+expression: "&wf"
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  labels:
+    ame-task: training
+  name: training
+  ownerReferences:
+    - apiVersion: ""
+      kind: ""
+      name: ""
+      uid: ""
+spec:
+  entrypoint: main
+  templates:
+    - name: main
+      metadata:
+        labels: ~
+        annotations: ~
+      steps:
+        - - name: setup
+            inline:
+              name: setup
+              metadata:
+                labels:
+                  ame-task: training
+                annotations: ~
+              steps: ~
+              securityContext:
+                fsGroup: 2000
+                runAsUser: 1001
+              script:
+                command:
+                  - bash
+                env:
+                  - name: AWS_ACCESS_KEY_ID
+                    valueFrom:
+                      secretKeyRef:
+                        key: MINIO_ROOT_USER
+                        name: ame-minio-secret
+                        optional: false
+                  - name: AWS_SECRET_ACCESS_KEY
+                    valueFrom:
+                      secretKeyRef:
+                        key: MINIO_ROOT_PASSWORD
+                        name: ame-minio-secret
+                        optional: false
+                  - name: MLFLOW_TRACKING_URI
+                    value: "http://mlflow.default.svc.cluster.local:5000"
+                  - name: MINIO_URL
+                    value: "http://ame-minio.ame-system.svc.cluster.local:9000"
+                  - name: PIPENV_YES
+                    value: "1"
+                image: "ghcr.io/teainspace/ame/ame-executor:0.0.3"
+                name: ""
+                resources: {}
+                volumeMounts:
+                  - mountPath: /project
+                    name: training-volume
+                source: "\n            git clone gitrepo .\n\n                       echo \"0\" >> exit.status\n                        "
+              podSpecPatch: ~
+        - - name: main
+            inline:
+              name: training
+              metadata:
+                labels:
+                  ame-task: training
+                annotations: ~
+              steps: ~
+              securityContext:
+                fsGroup: 2000
+                runAsUser: 1001
+              script:
+                command:
+                  - bash
+                env:
+                  - name: AWS_ACCESS_KEY_ID
+                    valueFrom:
+                      secretKeyRef:
+                        key: MINIO_ROOT_USER
+                        name: ame-minio-secret
+                        optional: false
+                  - name: AWS_SECRET_ACCESS_KEY
+                    valueFrom:
+                      secretKeyRef:
+                        key: MINIO_ROOT_PASSWORD
+                        name: ame-minio-secret
+                        optional: false
+                  - name: MLFLOW_TRACKING_URI
+                    value: "http://mlflow.default.svc.cluster.local:5000"
+                  - name: MINIO_URL
+                    value: "http://ame-minio.ame-system.svc.cluster.local:9000"
+                  - name: PIPENV_YES
+                    value: "1"
+                  - name: KEY1
+                    valueFrom:
+                      secretKeyRef:
+                        key: secret
+                        name: secret1
+                  - name: KEY2
+                    valueFrom:
+                      secretKeyRef:
+                        key: secret
+                        name: secret2
+                  - name: VAR1
+                    value: val1
+                  - name: VAR2
+                    value: val2
+                image: "ghcr.io/teainspace/ame/ame-executor:0.0.3"
+                name: ""
+                resources: {}
+                volumeMounts:
+                  - mountPath: /project
+                    name: training-volume
+                source: "\n          set -e # It is important that the workflow exits with an error code if execute or save_artifacts fails, so AME can take action based on that information.\n\n          exec python train.py\n\n                save_artifacts ame/tasks/training/artifacts/\n\n          echo \"0\" >> exit.status\n            "
+              podSpecPatch: "{\"containers\":[{\"name\":\"main\", \"resources\":{\"limits\":null}}]}"
+      securityContext: ~
+      script: ~
+      podSpecPatch: ~
+  imagePullSecrets: ~
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: training-volume
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi
+      status: {}
+  volumes: ~
+

--- a/controller/src/snapshots/controller__project__test__can_deploy_model-2.snap
+++ b/controller/src/snapshots/controller__project__test__can_deploy_model-2.snap
@@ -1,0 +1,20 @@
+---
+source: controller/src/project.rs
+expression: "&ingresses.get(&model_name).await?.spec"
+---
+ingressClassName: nginx
+rules:
+  - host: testhost
+    http:
+      paths:
+        - backend:
+            service:
+              name: test
+              port:
+                number: 5000
+          pathType: ImplementationSpecific
+tls:
+  - hosts:
+      - testhost
+    secretName: test-tls
+

--- a/controller/src/snapshots/controller__project__test__can_deploy_model-3.snap
+++ b/controller/src/snapshots/controller__project__test__can_deploy_model-3.snap
@@ -1,0 +1,50 @@
+---
+source: controller/src/project.rs
+expression: "&deployments.get(&model_name).await?.spec"
+---
+progressDeadlineSeconds: 600
+replicas: 1
+revisionHistoryLimit: 10
+selector:
+  matchLabels:
+    ame-model: test
+strategy:
+  rollingUpdate:
+    maxSurge: 25%
+    maxUnavailable: 25%
+  type: RollingUpdate
+template:
+  metadata:
+    labels:
+      ame-model: test
+  spec:
+    containers:
+      - command:
+          - mlflow serve -m test --enable-ml-server
+        env:
+          - name: MLFLOW_TRACKING_URI
+            value: "http://mlflow.default.svc.cluster.local:5000"
+        image: test_img
+        imagePullPolicy: Always
+        name: main
+        ports:
+          - containerPort: 5000
+            protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 5000
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+    dnsPolicy: ClusterFirst
+    restartPolicy: Always
+    schedulerName: default-scheduler
+    securityContext: {}
+    terminationGracePeriodSeconds: 30
+

--- a/controller/src/snapshots/controller__project__test__can_deploy_model.snap
+++ b/controller/src/snapshots/controller__project__test__can_deploy_model.snap
@@ -1,0 +1,20 @@
+---
+source: controller/src/project.rs
+expression: "&services.get(&model_name).await?.spec"
+---
+clusterIP: 10.43.197.162
+clusterIPs:
+  - 10.43.197.162
+internalTrafficPolicy: Cluster
+ipFamilies:
+  - IPv4
+ipFamilyPolicy: SingleStack
+ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+selector:
+  ame-model: test
+sessionAffinity: None
+type: ClusterIP
+

--- a/controller/src/snapshots/controller__project__test__produces_valid_deployment.snap
+++ b/controller/src/snapshots/controller__project__test__produces_valid_deployment.snap
@@ -1,0 +1,40 @@
+---
+source: controller/src/project.rs
+expression: "&project.spec.models.unwrap().clone()[0].generate_model_deployment(&ctrl_cfg,\n                \"model_source\".to_string()).await?"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    ame-model: test
+  name: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ame-model: test
+  template:
+    metadata:
+      labels:
+        ame-model: test
+    spec:
+      containers:
+        - args:
+            - "-c"
+            - "export PATH=$HOME/.pyenv/bin:$PATH; mlflow models serve -m model_source --host 0.0.0.0"
+          command:
+            - /bin/bash
+          env:
+            - name: MLFLOW_TRACKING_URI
+              value: "http://mlflow.default.svc.cluster.local:5000"
+          image: test_img
+          name: main
+          ports:
+            - containerPort: 5000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+          securityContext:
+            runAsUser: 1001
+

--- a/controller/src/snapshots/controller__project__test__produces_valid_ingress.snap
+++ b/controller/src/snapshots/controller__project__test__produces_valid_ingress.snap
@@ -1,0 +1,28 @@
+---
+source: controller/src/project.rs
+expression: "&project.spec.models.unwrap().clone()[0].generate_model_ingress(&ctrl_cfg)?"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations: {}
+  labels:
+    ame-model: test
+  name: test
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: testhost
+      http:
+        paths:
+          - backend:
+              service:
+                name: test
+                port:
+                  number: 5000
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - testhost
+      secretName: test-tls
+

--- a/controller/src/snapshots/controller__project__test__produces_valid_service.snap
+++ b/controller/src/snapshots/controller__project__test__produces_valid_service.snap
@@ -1,0 +1,16 @@
+---
+source: controller/src/project.rs
+expression: "&project.spec.models.unwrap().clone()[0].generate_model_service(&ctrl_cfg)?"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    ame-model: test
+  name: test
+spec:
+  ports:
+    - port: 5000
+  selector:
+    ame-model: test
+

--- a/controller/src/snapshots/controller__project_source__test__can_extract_projects_from_public_git_repository.snap
+++ b/controller/src/snapshots/controller__project_source__test__can_extract_projects_from_public_git_repository.snap
@@ -4,16 +4,10 @@ expression: "&projects"
 ---
 - projectid: echo
   tasks:
-    - runcommand: python echo.py myoutput
+    - name: echo
+      runcommand: python echo.py myoutput
       projectid: echo
-      env: ~
-      image: ~
-      secrets: ~
-      pipeline: ~
-      source:
-        gitrepository: ~
-        gitreference: ~
-        amestoragepath: ~
+      source: {}
       resources:
         cpu: "2"
         memory: 4Gi

--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -43,6 +43,6 @@ RUN pip install pipenv
 # Task execution.
 RUN pip install s3cmd
 
-RUN pip install mlflow
+RUN pip install mlflow[extras]
 
 WORKDIR /project

--- a/justfile
+++ b/justfile
@@ -61,6 +61,9 @@ test_server *ARGS:
 server_logs *ARGS:
   kubectl logs -n {{TARGET_NAMESPACE}} -l app=ame-server {{ARGS}}
 
+controller_logs *ARGS:
+  kubectl logs -n {{TARGET_NAMESPACE}} -l app=ame-controller {{ARGS}}
+
 review_snapshots:
   cargo insta review
 

--- a/manifests/controller/base/resources/controller.yaml
+++ b/manifests/controller/base/resources/controller.yaml
@@ -40,6 +40,38 @@ spec:
               configMapKeyRef:
                 name: ame-controller-configmap
                 key: executor_image
+          - name: AME_NAMESPACE
+            value: ame-system
+          - name: AME_MLFLOW_URL
+            value: http://mlflow.default.svc.cluster.local:5000
+          - name: AME_MODEL_DEPLOYMENT_INGRESS
+            value: |
+                apiVersion: networking.k8s.io/v1
+                kind: Ingress
+                metadata:
+                  name: grpc-ingress
+                  annotations:
+                    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+                    cert-manager.io/cluster-issuer: "letsencrypt-staging"
+                spec:
+                  ingressClassName: nginx
+                  rules:
+                  - host: grpc.20.76.43.59.nip.io   
+                    http:
+                      paths:
+                      - path: /
+                        pathType: ImplementationSpecific
+                        backend:
+                          service:
+                            name: grpc-service
+                            port:
+                              number: 50051
+                  tls: # < placing a host in the TLS config will determine what ends up in the cert's subjectAltNames
+                    - hosts:
+                      - 20.76.43.59.nip.io
+                      secretName: myingress-cert-grpc # < cert-manager will store the created certificate in this secret.
+                      serviceAccountName: ame-controller
+                      terminationGracePeriodSeconds: 10
       serviceAccountName: ame-controller
       terminationGracePeriodSeconds: 10
 ---

--- a/manifests/controller/base/resources/rbac.yaml
+++ b/manifests/controller/base/resources/rbac.yaml
@@ -158,3 +158,39 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -37,6 +37,9 @@ spec:
               image:
                 nullable: true
                 type: string
+              name:
+                nullable: true
+                type: string
               pipeline:
                 items:
                   properties:
@@ -77,6 +80,7 @@ spec:
                 nullable: true
                 type: array
               projectid:
+                nullable: true
                 type: string
               resources:
                 additionalProperties:
@@ -116,6 +120,7 @@ spec:
                 nullable: true
                 type: object
               runcommand:
+                nullable: true
                 type: string
               secrets:
                 items:
@@ -143,15 +148,15 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              taskRef:
+                nullable: true
+                type: string
               taskType:
                 enum:
                 - PipEnv
                 - Mlflow
                 nullable: true
                 type: string
-            required:
-            - projectid
-            - runcommand
             type: object
           status:
             description: The status object of `Task`

--- a/manifests/project_crd.yaml
+++ b/manifests/project_crd.yaml
@@ -21,6 +21,616 @@ spec:
         properties:
           spec:
             properties:
+              models:
+                items:
+                  properties:
+                    deployment:
+                      nullable: true
+                      properties:
+                        auto_train:
+                          type: boolean
+                        deploy:
+                          type: boolean
+                        enable_tls:
+                          nullable: true
+                          type: boolean
+                        image:
+                          nullable: true
+                          type: string
+                        ingress:
+                          description: Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
+                          nullable: true
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                clusterName:
+                                  description: The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+                                  type: string
+                                creationTimestamp:
+                                  description: |-
+                                    CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+                                    Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                  format: date-time
+                                  type: string
+                                deletionGracePeriodSeconds:
+                                  description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                                  format: int64
+                                  type: integer
+                                deletionTimestamp:
+                                  description: |-
+                                    DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+                                    Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                  format: date-time
+                                  type: string
+                                finalizers:
+                                  description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                                  items:
+                                    type: string
+                                  type: array
+                                generateName:
+                                  description: |-
+                                    GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                                    If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
+
+                                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                                  type: string
+                                generation:
+                                  description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                                  format: int64
+                                  type: integer
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                                managedFields:
+                                  description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                                  items:
+                                    description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+                                    properties:
+                                      apiVersion:
+                                        description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                        type: string
+                                      fieldsType:
+                                        description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                        type: string
+                                      fieldsV1:
+                                        description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                        type: object
+                                      manager:
+                                        description: Manager is an identifier of the workflow managing these fields.
+                                        type: string
+                                      operation:
+                                        description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                        type: string
+                                      subresource:
+                                        description: Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+                                        type: string
+                                      time:
+                                        description: Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'
+                                        format: date-time
+                                        type: string
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                                    Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                  type: string
+                                ownerReferences:
+                                  description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                                  items:
+                                    description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                                    properties:
+                                      apiVersion:
+                                        description: API version of the referent.
+                                        type: string
+                                      blockOwnerDeletion:
+                                        description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                        type: boolean
+                                      controller:
+                                        description: If true, this reference points to the managing controller.
+                                        type: boolean
+                                      kind:
+                                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                        type: string
+                                      uid:
+                                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                        type: string
+                                    required:
+                                    - apiVersion
+                                    - kind
+                                    - name
+                                    - uid
+                                    type: object
+                                  type: array
+                                resourceVersion:
+                                  description: |-
+                                    An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                  type: string
+                                selfLink:
+                                  description: |-
+                                    SelfLink is a URL representing this object. Populated by the system. Read-only.
+
+                                    DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                                  type: string
+                                uid:
+                                  description: |-
+                                    UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                                    Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                  type: string
+                              type: object
+                            spec:
+                              description: 'Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                              properties:
+                                defaultBackend:
+                                  description: DefaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.
+                                  properties:
+                                    resource:
+                                      description: Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    service:
+                                      description: Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".
+                                      properties:
+                                        name:
+                                          description: Name is the referenced service. The service must exist in the same namespace as the Ingress object.
+                                          type: string
+                                        port:
+                                          description: Port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+                                          properties:
+                                            name:
+                                              description: Name is the name of the port on the Service. This is a mutually exclusive setting with "Number".
+                                              type: string
+                                            number:
+                                              description: Number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                  type: object
+                                ingressClassName:
+                                  description: IngressClassName is the name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource. This replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field. The controller may emit a warning if the field and annotation have different values. Implementations of this API should ignore Ingresses without a class specified. An IngressClass resource may be marked as default, which can be used to set a default value for this field. For more information, refer to the IngressClass documentation.
+                                  type: string
+                                rules:
+                                  description: A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+                                  items:
+                                    description: IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+                                    properties:
+                                      host:
+                                        description: "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to\n   the IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.\n\nHost can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.bar.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. \"*.foo.com\"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == \"*\"). Requests will be matched against the Host field in the following way: 1. If Host is precise, the request matches this rule if the http host header is equal to Host. 2. If Host is a wildcard, then the request matches this rule if the http host header is to equal to the suffix (removing the first label) of the wildcard rule."
+                                        type: string
+                                      http:
+                                        description: 'HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last ''/'' and before the first ''?'' or ''#''.'
+                                        properties:
+                                          paths:
+                                            description: A collection of paths that map requests to backends.
+                                            items:
+                                              description: HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
+                                              properties:
+                                                backend:
+                                                  description: Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+                                                  properties:
+                                                    resource:
+                                                      description: Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+                                                      properties:
+                                                        apiGroup:
+                                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                          type: string
+                                                        kind:
+                                                          description: Kind is the type of resource being referenced
+                                                          type: string
+                                                        name:
+                                                          description: Name is the name of resource being referenced
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                    service:
+                                                      description: Service references a Service as a Backend. This is a mutually exclusive setting with "Resource".
+                                                      properties:
+                                                        name:
+                                                          description: Name is the referenced service. The service must exist in the same namespace as the Ingress object.
+                                                          type: string
+                                                        port:
+                                                          description: Port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+                                                          properties:
+                                                            name:
+                                                              description: Name is the name of the port on the Service. This is a mutually exclusive setting with "Number".
+                                                              type: string
+                                                            number:
+                                                              description: Number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".
+                                                              format: int32
+                                                              type: integer
+                                                          type: object
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                  type: object
+                                                path:
+                                                  description: Path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/' and must be present when using PathType with value "Exact" or "Prefix".
+                                                  type: string
+                                                pathType:
+                                                  description: |-
+                                                    PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+                                                      done on a path element by element basis. A path element refers is the
+                                                      list of labels in the path split by the '/' separator. A request is a
+                                                      match for path p if every p is an element-wise prefix of p of the
+                                                      request path. Note that if the last element of the path is a substring
+                                                      of the last element in request path, it is not a match (e.g. /foo/bar
+                                                      matches /foo/bar/baz, but does not match /foo/barbaz).
+                                                    * ImplementationSpecific: Interpretation of the Path matching is up to
+                                                      the IngressClass. Implementations can treat this as a separate PathType
+                                                      or treat it identically to Prefix or Exact path types.
+                                                    Implementations are required to support all path types.
+                                                  type: string
+                                              required:
+                                              - backend
+                                              - pathType
+                                              type: object
+                                            type: array
+                                        required:
+                                        - paths
+                                        type: object
+                                    type: object
+                                  type: array
+                                tls:
+                                  description: TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+                                  items:
+                                    description: IngressTLS describes the transport layer security associated with an Ingress.
+                                    properties:
+                                      hosts:
+                                        description: Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+                                        items:
+                                          type: string
+                                        type: array
+                                      secretName:
+                                        description: SecretName is the name of the secret used to terminate TLS traffic on port 443. Field is left optional to allow TLS routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            status:
+                              description: 'Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                              properties:
+                                loadBalancer:
+                                  description: LoadBalancer contains the current status of the load-balancer.
+                                  properties:
+                                    ingress:
+                                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                                      items:
+                                        description: 'LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                                        properties:
+                                          hostname:
+                                            description: Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                                            type: string
+                                          ip:
+                                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                                            type: string
+                                          ports:
+                                            description: Ports is a list of records of service ports If used, every port defined in the service should have an entry in it
+                                            items:
+                                              properties:
+                                                error:
+                                                  description: |-
+                                                    Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+                                                      CamelCase names
+                                                    - cloud provider specific error values must have names that comply with the
+                                                      format foo.example.com/CamelCase.
+                                                  type: string
+                                                port:
+                                                  description: Port is the port number of the service port of which status is recorded here
+                                                  format: int32
+                                                  type: integer
+                                                protocol:
+                                                  description: |+
+                                                    Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+
+                                                  type: string
+                                              required:
+                                              - port
+                                              - protocol
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                          required:
+                          - metadata
+                          type: object
+                        ingress_annotations:
+                          additionalProperties:
+                            type: string
+                          nullable: true
+                          type: object
+                        replicas:
+                          format: int32
+                          nullable: true
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          nullable: true
+                          properties:
+                            limits:
+                              additionalProperties:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      required:
+                      - auto_train
+                      - deploy
+                      type: object
+                    modelType:
+                      enum:
+                      - Mlflow
+                      nullable: true
+                      type: string
+                    name:
+                      type: string
+                    training:
+                      properties:
+                        schedule:
+                          nullable: true
+                          type: string
+                        task:
+                          properties:
+                            env:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              nullable: true
+                              type: array
+                            image:
+                              nullable: true
+                              type: string
+                            name:
+                              nullable: true
+                              type: string
+                            pipeline:
+                              items:
+                                properties:
+                                  env:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  runcommand:
+                                    type: string
+                                  secrets:
+                                    items:
+                                      properties:
+                                        envkey:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - envkey
+                                      - name
+                                      type: object
+                                    type: array
+                                  taskname:
+                                    type: string
+                                required:
+                                - env
+                                - runcommand
+                                - secrets
+                                - taskname
+                                type: object
+                              nullable: true
+                              type: array
+                            projectid:
+                              nullable: true
+                              type: string
+                            resources:
+                              additionalProperties:
+                                description: |-
+                                  Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.
+
+                                  The serialization format is:
+
+                                  <quantity>        ::= <signedNumber><suffix>
+                                    (Note that <suffix> may be empty, from the "" case in <decimalSI>.)
+                                  <digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= "+" | "-" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei
+                                    (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)
+                                  <decimalSI>       ::= m | "" | k | M | G | T | P | E
+                                    (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)
+                                  <decimalExponent> ::= "e" <signedNumber> | "E" <signedNumber>
+
+                                  No matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.
+
+                                  When a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.
+
+                                  Before serializing, Quantity will be put in "canonical form". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:
+                                    a. No precision is lost
+                                    b. No fractional digits will be emitted
+                                    c. The exponent (or suffix) is as large as possible.
+                                  The sign will be omitted unless the number is negative.
+
+                                  Examples:
+                                    1.5 will be serialized as "1500m"
+                                    1.5Gi will be serialized as "1536Mi"
+
+                                  Note that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.
+
+                                  Non-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)
+
+                                  This format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.
+                                type: string
+                              nullable: true
+                              type: object
+                            runcommand:
+                              nullable: true
+                              type: string
+                            secrets:
+                              items:
+                                properties:
+                                  envkey:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - envkey
+                                - name
+                                type: object
+                              nullable: true
+                              type: array
+                            source:
+                              nullable: true
+                              properties:
+                                amestoragepath:
+                                  nullable: true
+                                  type: string
+                                gitreference:
+                                  nullable: true
+                                  type: string
+                                gitrepository:
+                                  nullable: true
+                                  type: string
+                              type: object
+                            taskRef:
+                              nullable: true
+                              type: string
+                            taskType:
+                              enum:
+                              - PipEnv
+                              - Mlflow
+                              nullable: true
+                              type: string
+                          type: object
+                      required:
+                      - task
+                      type: object
+                  required:
+                  - name
+                  - training
+                  type: object
+                nullable: true
+                type: array
               projectid:
                 type: string
               tasks:
@@ -40,6 +650,9 @@ spec:
                       nullable: true
                       type: array
                     image:
+                      nullable: true
+                      type: string
+                    name:
                       nullable: true
                       type: string
                     pipeline:
@@ -82,6 +695,7 @@ spec:
                       nullable: true
                       type: array
                     projectid:
+                      nullable: true
                       type: string
                     resources:
                       additionalProperties:
@@ -121,6 +735,7 @@ spec:
                       nullable: true
                       type: object
                     runcommand:
+                      nullable: true
                       type: string
                     secrets:
                       items:
@@ -148,15 +763,15 @@ spec:
                           nullable: true
                           type: string
                       type: object
+                    taskRef:
+                      nullable: true
+                      type: string
                     taskType:
                       enum:
                       - PipEnv
                       - Mlflow
                       nullable: true
                       type: string
-                  required:
-                  - projectid
-                  - runcommand
                   type: object
                 nullable: true
                 type: array
@@ -179,6 +794,9 @@ spec:
                     image:
                       nullable: true
                       type: string
+                    name:
+                      nullable: true
+                      type: string
                     pipeline:
                       items:
                         properties:
@@ -219,6 +837,7 @@ spec:
                       nullable: true
                       type: array
                     projectid:
+                      nullable: true
                       type: string
                     resources:
                       additionalProperties:
@@ -258,6 +877,7 @@ spec:
                       nullable: true
                       type: object
                     runcommand:
+                      nullable: true
                       type: string
                     secrets:
                       items:
@@ -285,15 +905,15 @@ spec:
                           nullable: true
                           type: string
                       type: object
+                    taskRef:
+                      nullable: true
+                      type: string
                     taskType:
                       enum:
                       - PipEnv
                       - Mlflow
                       nullable: true
                       type: string
-                  required:
-                  - projectid
-                  - runcommand
                   type: object
                 nullable: true
                 type: array
@@ -302,6 +922,32 @@ spec:
             type: object
           status:
             nullable: true
+            properties:
+              models:
+                items:
+                  properties:
+                    lastDeployed:
+                      description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastTrained:
+                      description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    latestModelVersion:
+                      description: Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                nullable: true
+                type: array
             type: object
         required:
         - spec

--- a/manifests/project_src_crd.yaml
+++ b/manifests/project_src_crd.yaml
@@ -29,7 +29,7 @@ spec:
                   secret:
                     nullable: true
                     type: string
-                  syncInternal:
+                  syncInterval:
                     nullable: true
                     properties:
                       nanos:

--- a/manifests/server/base/resources/rbac.yaml
+++ b/manifests/server/base/resources/rbac.yaml
@@ -44,6 +44,24 @@ rules:
   - tasks/status
   verbs:
   - get
+- apiGroups:
+  - ame.teainspace.com
+  resources:
+  - projectsources 
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ame.teainspace.com
+  resources:
+  - projectsources/status
+  verbs:
+  - get
 - apiGroups: 
   - ""
   resources: 

--- a/proto/ame.proto
+++ b/proto/ame.proto
@@ -65,6 +65,9 @@ message ProjectSource {
 
 message GitProjectSource {
   string repository = 1;
+  optional string username = 2;
+  optional string secret = 3;
+  optional string sync_interval = 4;
 }
 
 service AmeService {
@@ -74,4 +77,5 @@ service AmeService {
   rpc CreateTaskProjectDirectory(TaskProjectDirectoryStructure) returns (Empty) {}
   rpc UploadProjectFile(stream ProjectFileChunk) returns (Empty) {}
   rpc StreamTaskLogs(TaskLogRequest) returns (stream LogEntry) {}
+  rpc CreateProjectSrc(ProjectSource) returns (Empty) {}
 }

--- a/test_data/test_projects/sklearn_logistic_regression/train.py
+++ b/test_data/test_projects/sklearn_logistic_regression/train.py
@@ -13,5 +13,5 @@ if __name__ == "__main__":
     score = lr.score(X, y)
     print("Score: %s" % score)
     mlflow.log_metric("score", score)
-    mlflow.sklearn.log_model(lr, "model")
+    mlflow.sklearn.log_model(lr, "model", registered_model_name="test_model")
     print("Model saved in run %s" % mlflow.active_run().info.run_uuid)


### PR DESCRIPTION
Issue: #93

Serving models over an API is an important requirement for AME.

Therefore this commit implements model serving using Mlflow's serving
capabilities. This includes watching Mlflow model registry to update
deployments to the latest model version as well as training a model if
no model is present.

Extra:

To facilitate testing this functionality a new RPC was exposed through
the CLI to easily add Git repositories as project sources.
