### PR TITLE
Implement Hashicorp Vault integration for Tasks

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,10 @@ enum Commands {
     Setup {
         endpoint: String,
     },
+    Train {
+        project: String,
+        model: String,
+    },
     #[command(subcommand)]
     Create(CreateCommands),
 }
@@ -58,6 +62,17 @@ async fn main() -> Result<()> {
 
             Ok(())
         }
+        Commands::Train { project, model } => {
+            let mut client = AmeServiceClient::connect(config.endpoint).await?;
+
+            client
+                .train_model(Request::new(ame_client::TrainRequest {
+                    projectid: project.to_string(),
+                    model_name: model.to_string(),
+                }))
+                .await?;
+            Ok(())
+        }
         Commands::Create(CreateCommands::Projectsrc { repository }) => {
             let mut client = AmeServiceClient::connect(config.endpoint).await?;
 
@@ -65,6 +80,7 @@ async fn main() -> Result<()> {
                 .create_project_src(Request::new(ame_client::ProjectSource {
                     git: Some(ame_client::GitProjectSource {
                         repository: repository.to_string(),
+                        sync_interval: Some("10s".to_string()),
                         ..ame_client::GitProjectSource::default()
                     }),
                 }))

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -65,6 +65,8 @@ pub use argo::Workflow;
 pub use argo::WorkflowPhase;
 
 pub mod project;
+pub use project::*;
+
 pub mod project_source;
 pub use project_source::GitProjectSource;
 pub use project_source::ProjectSource;

--- a/controller/src/snapshots/controller__manager__test__task_can_generate_workflow.snap
+++ b/controller/src/snapshots/controller__manager__test__task_can_generate_workflow.snap
@@ -134,4 +134,5 @@ spec:
             storage: 50Gi
       status: {}
   volumes: ~
+  serviceAccountName: ame-task
 

--- a/controller/src/snapshots/controller__manager__test__task_can_have_vault_secret.snap
+++ b/controller/src/snapshots/controller__manager__test__task_can_have_vault_secret.snap
@@ -60,7 +60,7 @@ spec:
                 volumeMounts:
                   - mountPath: /project
                     name: training-volume
-                source: "\n            git clone gitrepo .\n\n                       echo \"0\" >> exit.status\n                        "
+                source: "\n            s3cmd --no-ssl --region eu-central-1 --host=$MINIO_URL --host-bucket=$MINIO_URL get --recursive s3://ame/tasks/training/projectfiles/ ./\n\n                       echo \"0\" >> exit.status\n                        "
               podSpecPatch: ~
         - - name: main
             inline:
@@ -68,7 +68,11 @@ spec:
               metadata:
                 labels:
                   ame-task: training
-                annotations: ~
+                annotations:
+                  vault.hashicorp.com/agent-inject: "true"
+                  vault.hashicorp.com/agent-inject-secret-config: internal/data/database/config
+                  vault.hashicorp.com/agent-inject-template-config: "{{- with secret \"/my/secret/path\" -}}\n            export KEY1=\"{{ .Data.mysecret }}\"\n          {{- end -}}"
+                  vault.hashicorp.com/role: ame-task
               steps: ~
               securityContext:
                 fsGroup: 2000
@@ -95,11 +99,6 @@ spec:
                     value: "http://ame-minio.ame-system.svc.cluster.local:9000"
                   - name: PIPENV_YES
                     value: "1"
-                  - name: KEY1
-                    valueFrom:
-                      secretKeyRef:
-                        key: secret
-                        name: secret1
                   - name: KEY2
                     valueFrom:
                       secretKeyRef:
@@ -115,7 +114,7 @@ spec:
                 volumeMounts:
                   - mountPath: /project
                     name: training-volume
-                source: "\n          set -e # It is important that the workflow exits with an error code if execute or save_artifacts fails, so AME can take action based on that information.\n\n          exec python train.py\n\n                save_artifacts ame/tasks/training/artifacts/\n\n          echo \"0\" >> exit.status\n            "
+                source: "\n                source /vault/secrets/config\n\n                \n          set -e # It is important that the workflow exits with an error code if execute or save_artifacts fails, so AME can take action based on that information.\n\n          exec python train.py\n\n                save_artifacts ame/tasks/training/artifacts/\n\n          echo \"0\" >> exit.status\n            "
               podSpecPatch: "{\"containers\":[{\"name\":\"main\", \"resources\":{\"limits\":null}}]}"
       securityContext: ~
       script: ~

--- a/controller/src/snapshots/controller__manager__test__task_can_override_workflow_image.snap
+++ b/controller/src/snapshots/controller__manager__test__task_can_override_workflow_image.snap
@@ -134,4 +134,5 @@ spec:
             storage: 50Gi
       status: {}
   volumes: ~
+  serviceAccountName: ame-task
 

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -59,14 +59,38 @@ spec:
                       type: string
                     secrets:
                       items:
+                        oneOf:
+                        - required:
+                          - AmeSecret
+                        - required:
+                          - VaultSecret
                         properties:
-                          envkey:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - envkey
-                        - name
+                          AmeSecret:
+                            properties:
+                              envkey:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - envkey
+                            - name
+                            type: object
+                          VaultSecret:
+                            properties:
+                              envkey:
+                                type: string
+                              secretKey:
+                                type: string
+                              secretPath:
+                                type: string
+                              vaultName:
+                                type: string
+                            required:
+                            - envkey
+                            - secretKey
+                            - secretPath
+                            - vaultName
+                            type: object
                         type: object
                       type: array
                     taskname:
@@ -124,14 +148,38 @@ spec:
                 type: string
               secrets:
                 items:
+                  oneOf:
+                  - required:
+                    - AmeSecret
+                  - required:
+                    - VaultSecret
                   properties:
-                    envkey:
-                      type: string
-                    name:
-                      type: string
-                  required:
-                  - envkey
-                  - name
+                    AmeSecret:
+                      properties:
+                        envkey:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - envkey
+                      - name
+                      type: object
+                    VaultSecret:
+                      properties:
+                        envkey:
+                          type: string
+                        secretKey:
+                          type: string
+                        secretPath:
+                          type: string
+                        vaultName:
+                          type: string
+                      required:
+                      - envkey
+                      - secretKey
+                      - secretPath
+                      - vaultName
+                      type: object
                   type: object
                 nullable: true
                 type: array

--- a/manifests/project_crd.yaml
+++ b/manifests/project_crd.yaml
@@ -523,14 +523,38 @@ spec:
                                     type: string
                                   secrets:
                                     items:
+                                      oneOf:
+                                      - required:
+                                        - AmeSecret
+                                      - required:
+                                        - VaultSecret
                                       properties:
-                                        envkey:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - envkey
-                                      - name
+                                        AmeSecret:
+                                          properties:
+                                            envkey:
+                                              type: string
+                                            name:
+                                              type: string
+                                          required:
+                                          - envkey
+                                          - name
+                                          type: object
+                                        VaultSecret:
+                                          properties:
+                                            envkey:
+                                              type: string
+                                            secretKey:
+                                              type: string
+                                            secretPath:
+                                              type: string
+                                            vaultName:
+                                              type: string
+                                          required:
+                                          - envkey
+                                          - secretKey
+                                          - secretPath
+                                          - vaultName
+                                          type: object
                                       type: object
                                     type: array
                                   taskname:
@@ -588,14 +612,38 @@ spec:
                               type: string
                             secrets:
                               items:
+                                oneOf:
+                                - required:
+                                  - AmeSecret
+                                - required:
+                                  - VaultSecret
                                 properties:
-                                  envkey:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - envkey
-                                - name
+                                  AmeSecret:
+                                    properties:
+                                      envkey:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - envkey
+                                    - name
+                                    type: object
+                                  VaultSecret:
+                                    properties:
+                                      envkey:
+                                        type: string
+                                      secretKey:
+                                        type: string
+                                      secretPath:
+                                        type: string
+                                      vaultName:
+                                        type: string
+                                    required:
+                                    - envkey
+                                    - secretKey
+                                    - secretPath
+                                    - vaultName
+                                    type: object
                                 type: object
                               nullable: true
                               type: array
@@ -674,14 +722,38 @@ spec:
                             type: string
                           secrets:
                             items:
+                              oneOf:
+                              - required:
+                                - AmeSecret
+                              - required:
+                                - VaultSecret
                               properties:
-                                envkey:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - envkey
-                              - name
+                                AmeSecret:
+                                  properties:
+                                    envkey:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - envkey
+                                  - name
+                                  type: object
+                                VaultSecret:
+                                  properties:
+                                    envkey:
+                                      type: string
+                                    secretKey:
+                                      type: string
+                                    secretPath:
+                                      type: string
+                                    vaultName:
+                                      type: string
+                                  required:
+                                  - envkey
+                                  - secretKey
+                                  - secretPath
+                                  - vaultName
+                                  type: object
                               type: object
                             type: array
                           taskname:
@@ -739,14 +811,38 @@ spec:
                       type: string
                     secrets:
                       items:
+                        oneOf:
+                        - required:
+                          - AmeSecret
+                        - required:
+                          - VaultSecret
                         properties:
-                          envkey:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - envkey
-                        - name
+                          AmeSecret:
+                            properties:
+                              envkey:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - envkey
+                            - name
+                            type: object
+                          VaultSecret:
+                            properties:
+                              envkey:
+                                type: string
+                              secretKey:
+                                type: string
+                              secretPath:
+                                type: string
+                              vaultName:
+                                type: string
+                            required:
+                            - envkey
+                            - secretKey
+                            - secretPath
+                            - vaultName
+                            type: object
                         type: object
                       nullable: true
                       type: array
@@ -816,14 +912,38 @@ spec:
                             type: string
                           secrets:
                             items:
+                              oneOf:
+                              - required:
+                                - AmeSecret
+                              - required:
+                                - VaultSecret
                               properties:
-                                envkey:
-                                  type: string
-                                name:
-                                  type: string
-                              required:
-                              - envkey
-                              - name
+                                AmeSecret:
+                                  properties:
+                                    envkey:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - envkey
+                                  - name
+                                  type: object
+                                VaultSecret:
+                                  properties:
+                                    envkey:
+                                      type: string
+                                    secretKey:
+                                      type: string
+                                    secretPath:
+                                      type: string
+                                    vaultName:
+                                      type: string
+                                  required:
+                                  - envkey
+                                  - secretKey
+                                  - secretPath
+                                  - vaultName
+                                  type: object
                               type: object
                             type: array
                           taskname:
@@ -881,14 +1001,38 @@ spec:
                       type: string
                     secrets:
                       items:
+                        oneOf:
+                        - required:
+                          - AmeSecret
+                        - required:
+                          - VaultSecret
                         properties:
-                          envkey:
-                            type: string
-                          name:
-                            type: string
-                        required:
-                        - envkey
-                        - name
+                          AmeSecret:
+                            properties:
+                              envkey:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - envkey
+                            - name
+                            type: object
+                          VaultSecret:
+                            properties:
+                              envkey:
+                                type: string
+                              secretKey:
+                                type: string
+                              secretPath:
+                                type: string
+                              vaultName:
+                                type: string
+                            required:
+                            - envkey
+                            - secretKey
+                            - secretPath
+                            - vaultName
+                            type: object
                         type: object
                       nullable: true
                       type: array

--- a/manifests/server/base/resources/rbac.yaml
+++ b/manifests/server/base/resources/rbac.yaml
@@ -18,6 +18,9 @@ subjects:
 - kind: ServiceAccount
   name: ame-server
   namespace: ame-system
+- kind: ServiceAccount
+  name: ame-task
+  namespace: ame-system
 
 ---
 
@@ -72,3 +75,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ame.teainspace.com
+  resources:
+  - projects
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+

--- a/proto/ame.proto
+++ b/proto/ame.proto
@@ -70,6 +70,11 @@ message GitProjectSource {
   optional string sync_interval = 4;
 }
 
+message TrainRequest {
+  string projectid = 1;
+  string model_name = 2;
+}
+
 service AmeService {
   rpc GetTask(TaskIdentifier) returns (TaskTemplate) {}
   rpc CreateTask(CreateTaskRequest) returns (TaskIdentifier) {}
@@ -78,4 +83,5 @@ service AmeService {
   rpc UploadProjectFile(stream ProjectFileChunk) returns (Empty) {}
   rpc StreamTaskLogs(TaskLogRequest) returns (stream LogEntry) {}
   rpc CreateProjectSrc(ProjectSource) returns (Empty) {}
+  rpc TrainModel(TrainRequest) returns (Empty) {}
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -51,6 +51,9 @@ pub enum Error {
 
     #[error("Got error from formatting: {0}")]
     FormatError(#[from] FromUtf8Error),
+
+    #[error("Failed to find the requested model: {0}")]
+    MissingModel(String),
 }
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 


### PR DESCRIPTION
Issue: #91

This commit implements support for injecting Vault secrets as
environment variables for Tasks.

This helps facilitate adoption of AME for users that store secrets in
Vault.

Extra:

Expose a remote model training RPC to help test this feature.
